### PR TITLE
feat: add --exclude-tests flag to filter out test code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@
 
 ```sh
 cargo build          # Build
-cargo test           # Run all 131 tests (112 unit + 19 integration)
+cargo test           # Run all 140 tests (119 unit + 21 integration)
 cargo clippy         # Lint (must be clean)
 cargo fmt --check    # Format check
 ```
@@ -31,7 +31,7 @@ scan_files → parse_files → group_exact_duplicates → find_near_duplicates �
 |--------|------|---------------|
 | **normalizer** | `src/normalizer.rs` | Core AST normalization. Defines `NormalizedNode` enum (~30 variants), `NormalizationContext` for identifier-to-placeholder mapping, and normalization functions for expressions, statements, patterns, types, and signatures. |
 | **fingerprint** | `src/fingerprint.rs` | `Fingerprint` struct wrapping `u64` from `DefaultHasher`. Supports hex serialization. |
-| **parser** | `src/parser.rs` | `CodeUnit` extraction using `syn::visit::Visit`. Visits `ItemFn`, `ItemImpl`, `ExprClosure`. Extracts units above `min_node_count` and `min_line_count` thresholds. |
+| **parser** | `src/parser.rs` | `CodeUnit` extraction using `syn::visit::Visit`. Visits `ItemFn`, `ItemImpl`, `ItemMod`, `ExprClosure`. Extracts units above `min_node_count` and `min_line_count` thresholds. Supports `exclude_tests` to skip `#[test]` functions and `#[cfg(test)]` modules/impl blocks. |
 | **scanner** | `src/scanner.rs` | File discovery via `walkdir`. Skips `target/` and hidden directories. Respects exclude patterns. |
 | **similarity** | `src/similarity.rs` | Recursive tree comparison using Dice coefficient: `score = (2 * matching) / (nodes_a + nodes_b)`. |
 | **grouper** | `src/grouper.rs` | Exact duplicate grouping via `HashMap<Fingerprint, Vec<CodeUnit>>`. Near-duplicate detection with size-bucket pre-filtering and union-find for transitive closure. |
@@ -56,7 +56,7 @@ This enables `derive(Hash)` for fingerprinting and recursive tree comparison for
 - `CodeUnit` — A function, method, closure, or impl block extracted from source. Contains normalized signature + body, fingerprint, file location, line numbers.
 - `DuplicateGroup` — A group of code units with the same fingerprint (exact) or above the similarity threshold (near).
 - `DuplicationStats` — Statistics including group/unit counts and duplicated line counts (exact and near).
-- `Config` — All analysis parameters (min_nodes, min_lines, similarity_threshold, excludes, CI thresholds).
+- `Config` — All analysis parameters (min_nodes, min_lines, similarity_threshold, excludes, exclude_tests, CI thresholds).
 
 ## CLI Subcommands
 
@@ -70,7 +70,7 @@ This enables `derive(Hash)` for fingerprinting and recursive tree comparison for
 
 - **Unit tests** are colocated in each module (`#[cfg(test)] mod tests`).
 - **Integration tests** are in `tests/cli_integration.rs` using `assert_cmd` + `predicates`.
-- **Fixtures** are in `tests/fixtures/` with 4 minimal Rust projects: `exact_dupes`, `near_dupes`, `no_dupes`, `mixed`.
+- **Fixtures** are in `tests/fixtures/` with 5 minimal Rust projects: `exact_dupes`, `near_dupes`, `no_dupes`, `mixed`, `test_code`.
 
 ## syn 2 Gotchas
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Options:
       --threshold <THRESHOLD>  Similarity threshold for near-duplicates (0.0-1.0) [default: 0.8]
       --format <FORMAT>        Output format [default: text] [possible values: text, json]
       --exclude <EXCLUDE>      Exclude patterns (can be repeated)
+      --exclude-tests          Exclude test code (#[test] functions and #[cfg(test)] modules)
 ```
 
 ### Examples
@@ -114,7 +115,13 @@ $ cargo dupes check --max-exact 0
 # Exits with code 0 if within thresholds
 ```
 
-**Exclude test files:**
+**Exclude test code (inline `#[cfg(test)]` modules and `#[test]` functions):**
+
+```sh
+$ cargo dupes --exclude-tests report
+```
+
+**Exclude test directories by path:**
 
 ```sh
 $ cargo dupes --exclude tests --exclude benches report
@@ -147,6 +154,7 @@ min_nodes = 15
 min_lines = 5
 similarity_threshold = 0.85
 exclude = ["tests", "benches"]
+exclude_tests = true
 max_exact_duplicates = 0
 max_near_duplicates = 10
 ```
@@ -168,6 +176,7 @@ exclude = ["tests"]
 | `min_lines` | `0` | Minimum source line count for a code unit to be analyzed. `0` means disabled. |
 | `similarity_threshold` | `0.8` | Minimum similarity score (0.0-1.0) for near-duplicate detection. |
 | `exclude` | `[]` | Path patterns to exclude from scanning (substring match). |
+| `exclude_tests` | `false` | Exclude `#[test]` functions and `#[cfg(test)]` modules from analysis. |
 | `max_exact_duplicates` | `None` | For `check` subcommand: maximum allowed exact duplicate groups. |
 | `max_near_duplicates` | `None` | For `check` subcommand: maximum allowed near-duplicate groups. |
 
@@ -228,7 +237,7 @@ The scanner automatically:
 
 ```sh
 cargo build          # Build
-cargo test           # Run all 131 tests
+cargo test           # Run all 140 tests
 cargo clippy         # Lint check
 cargo fmt --check    # Format check
 ```

--- a/src/grouper.rs
+++ b/src/grouper.rs
@@ -235,7 +235,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let file = tmp.path().join("test.rs");
         fs::write(&file, code).unwrap();
-        parser::parse_file(&file, 1, 0).unwrap()
+        parser::parse_file(&file, 1, 0, false).unwrap()
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,12 @@ pub fn analyze(config: &Config) -> error::Result<AnalysisResult> {
     }
 
     // 2. Parse all files
-    let (units, warnings) = parser::parse_files(&files, config.min_nodes, config.min_lines);
+    let (units, warnings) = parser::parse_files(
+        &files,
+        config.min_nodes,
+        config.min_lines,
+        config.exclude_tests,
+    );
 
     // 3. Group exact duplicates
     let exact_groups = grouper::group_exact_duplicates(&units);

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,10 @@ struct Cli {
     /// Exclude patterns (can be repeated).
     #[arg(long, global = true)]
     exclude: Vec<String>,
+
+    /// Exclude test code (#[test] functions and #[cfg(test)] modules).
+    #[arg(long, global = true)]
+    exclude_tests: bool,
 }
 
 #[derive(Clone, clap::ValueEnum)]
@@ -147,6 +151,9 @@ fn main() {
     }
     if !cli.exclude.is_empty() {
         config.exclude = cli.exclude;
+    }
+    if cli.exclude_tests {
+        config.exclude_tests = true;
     }
 
     let result = match cargo_dupes::analyze(&config) {

--- a/tests/fixtures/test_code/Cargo.toml
+++ b/tests/fixtures/test_code/Cargo.toml
@@ -1,0 +1,4 @@
+[package]
+name = "test_code"
+version = "0.1.0"
+edition = "2021"

--- a/tests/fixtures/test_code/src/lib.rs
+++ b/tests/fixtures/test_code/src/lib.rs
@@ -1,0 +1,32 @@
+pub fn sum_values(items: &[i32]) -> i32 {
+    let mut total = 0;
+    for item in items {
+        if *item > 0 {
+            total += item;
+        }
+    }
+    total
+}
+
+pub fn count_values(items: &[i32]) -> i32 {
+    let mut total = 0;
+    for item in items {
+        if *item > 0 {
+            total += item;
+        }
+    }
+    total
+}
+
+#[cfg(test)]
+mod tests {
+    pub fn test_helper(items: &[i32]) -> i32 {
+        let mut total = 0;
+        for item in items {
+            if *item > 0 {
+                total += item;
+            }
+        }
+        total
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `--exclude-tests` CLI flag that filters out test code at the AST level during parsing
- Excludes `#[test]` functions, `#[cfg(test)]` modules (entire module skipped), and `#[cfg(test)]` impl blocks
- Configurable via CLI flag, `dupes.toml` (`exclude_tests = true`), or `Cargo.toml` metadata
- Adds 7 new unit tests and 2 integration tests (140 total: 119 unit + 21 integration)

## Test plan

- [x] All 140 tests pass (`cargo test`)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Manual test: `cargo run -- --exclude-tests --path tests/fixtures/test_code stats` shows 2 units (test code excluded)
- [x] Manual test: `cargo run -- --path tests/fixtures/test_code stats` shows 3 units (test code included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)