### PR TITLE
fix(ci): trigger release on GitHub release instead of tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [published]
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- Switch release workflow trigger from `push: tags: v*` to `release: published`
- The tag push event wasn't firing for tags created by release-please; the `release: published` event fires reliably when release-please creates the GitHub release

## Test plan

- [ ] Merge this PR, then merge the next release-please PR — verify the publish job runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)