### PR TITLE
fix: make all check thresholds default to disabled when not set

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -205,10 +205,8 @@ fn main() {
             max_exact_percent,
             max_near_percent,
         } => {
-            let max_exact = max_exact.or(config.max_exact_duplicates).unwrap_or(0);
-            let max_near = max_near
-                .or(config.max_near_duplicates)
-                .unwrap_or(usize::MAX);
+            let max_exact = max_exact.or(config.max_exact_duplicates);
+            let max_near = max_near.or(config.max_near_duplicates);
             let max_exact_pct = max_exact_percent.or(config.max_exact_percent);
             let max_near_pct = max_near_percent.or(config.max_near_percent);
 
@@ -216,11 +214,13 @@ fn main() {
 
             let mut failed = false;
 
-            if result.stats.exact_duplicate_groups > max_exact {
+            if let Some(threshold) = max_exact
+                && result.stats.exact_duplicate_groups > threshold
+            {
                 writeln!(
                     writer,
                     "\nCheck FAILED: {} exact duplicate groups (max: {})",
-                    result.stats.exact_duplicate_groups, max_exact
+                    result.stats.exact_duplicate_groups, threshold
                 )
                 .unwrap();
                 reporter
@@ -229,11 +229,13 @@ fn main() {
                 failed = true;
             }
 
-            if result.stats.near_duplicate_groups > max_near {
+            if let Some(threshold) = max_near
+                && result.stats.near_duplicate_groups > threshold
+            {
                 writeln!(
                     writer,
                     "\nCheck FAILED: {} near duplicate groups (max: {})",
-                    result.stats.near_duplicate_groups, max_near
+                    result.stats.near_duplicate_groups, threshold
                 )
                 .unwrap();
                 reporter

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -71,6 +71,20 @@ fn stats_shows_summary() {
 // ── Check subcommand ────────────────────────────────────────────────────
 
 #[test]
+fn check_no_thresholds_passes_with_duplicates() {
+    // With no thresholds set, check should pass even when duplicates exist
+    cargo_dupes()
+        .args([
+            "--path",
+            fixture_path("exact_dupes").to_str().unwrap(),
+            "check",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Check passed"));
+}
+
+#[test]
 fn check_fails_with_duplicates() {
     cargo_dupes()
         .args([


### PR DESCRIPTION
## Summary

- `--max-exact` previously defaulted to `0`, causing `check` to reject any duplicates even when no threshold was configured
- `--max-near` previously defaulted to `usize::MAX` (effectively disabled, but inconsistent)
- Now all four thresholds (`--max-exact`, `--max-near`, `--max-exact-percent`, `--max-near-percent`) are `Option`-based and only enforced when explicitly set via CLI flags or config file

## Test plan

- [x] New integration test: `check` with no thresholds passes even when duplicates exist
- [x] Existing tests for explicit thresholds still pass
- [x] All 148 tests pass (123 unit + 25 integration)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)