### PR TITLE
feat: composite fingerprints for near-duplicate groups + cleanup command

### DIFF
--- a/src/output/json.rs
+++ b/src/output/json.rs
@@ -186,8 +186,9 @@ mod tests {
     #[test]
     fn json_report_near_with_groups() {
         let reporter = JsonReporter::new(None);
+        let fp = Fingerprint::from_node(&NormalizedNode::Block(vec![]));
         let group = DuplicateGroup {
-            fingerprint: None,
+            fingerprint: Some(fp),
             members: vec![
                 make_unit("process", "/src/a.rs", 10, 25),
                 make_unit("compute", "/src/b.rs", 30, 45),
@@ -200,7 +201,7 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
         let groups = parsed.as_array().unwrap();
         assert_eq!(groups.len(), 1);
-        assert!(groups[0]["fingerprint"].is_null());
+        assert_eq!(groups[0]["fingerprint"].as_str().unwrap(), fp.to_hex());
         assert_eq!(groups[0]["similarity"], 0.85);
     }
 
@@ -222,8 +223,9 @@ mod tests {
     #[test]
     fn json_relative_paths() {
         let reporter = JsonReporter::new(Some(PathBuf::from("/home/user/project")));
+        let fp = Fingerprint::from_node(&NormalizedNode::Block(vec![]));
         let group = DuplicateGroup {
-            fingerprint: None,
+            fingerprint: Some(fp),
             members: vec![make_unit("foo", "/home/user/project/src/main.rs", 1, 10)],
             similarity: 0.9,
         };

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -472,6 +472,182 @@ fn check_absolute_passes_percentage_fails() {
         .stdout(predicate::str::contains("Check FAILED"));
 }
 
+// ── Near-duplicate ignore workflow ───────────────────────────────────────
+
+#[test]
+fn ignore_near_duplicate_workflow() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    // Copy fixture files to temp dir
+    std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+    std::fs::copy(
+        fixture_path("near_dupes").join("src/lib.rs"),
+        tmp.path().join("src/lib.rs"),
+    )
+    .unwrap();
+
+    // Get report to find a near-duplicate fingerprint
+    let output = cargo_dupes()
+        .args([
+            "--path",
+            tmp.path().to_str().unwrap(),
+            "--threshold",
+            "0.7",
+            "report",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(output).unwrap();
+
+    // Extract fingerprint from near-duplicate group
+    let fp = text
+        .lines()
+        .find(|l| l.contains("fingerprint:") && l.contains("similarity:"))
+        .and_then(|l| {
+            let start = l.find("fingerprint: ")? + 13;
+            let end = l[start..].find(',')?;
+            Some(l[start..start + end].to_string())
+        })
+        .expect("Should find a fingerprint in near-duplicate group");
+
+    // Add it to ignore
+    cargo_dupes()
+        .args([
+            "--path",
+            tmp.path().to_str().unwrap(),
+            "ignore",
+            &fp,
+            "--reason",
+            "near dupe ignore test",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Added"));
+
+    // Verify the near-duplicate group is now filtered out
+    let output_after = cargo_dupes()
+        .args([
+            "--path",
+            tmp.path().to_str().unwrap(),
+            "--threshold",
+            "0.7",
+            "stats",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text_after = String::from_utf8(output_after).unwrap();
+    assert!(text_after.contains("Near duplicates:  0 groups"));
+}
+
+// ── Cleanup subcommand ──────────────────────────────────────────────────
+
+#[test]
+fn cleanup_removes_stale_entries() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+    std::fs::copy(
+        fixture_path("exact_dupes").join("src/lib.rs"),
+        tmp.path().join("src/lib.rs"),
+    )
+    .unwrap();
+
+    // Get a real fingerprint from the report
+    let output = cargo_dupes()
+        .args(["--path", tmp.path().to_str().unwrap(), "report"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(output).unwrap();
+
+    let real_fp = text
+        .lines()
+        .find(|l| l.contains("fingerprint:"))
+        .and_then(|l| {
+            let start = l.find("fingerprint: ")? + 13;
+            let end = l[start..].find(',')?;
+            Some(l[start..start + end].to_string())
+        })
+        .expect("Should find a fingerprint");
+
+    // Ignore the real fingerprint
+    cargo_dupes()
+        .args(["--path", tmp.path().to_str().unwrap(), "ignore", &real_fp])
+        .assert()
+        .success();
+
+    // Add a fake/stale fingerprint manually
+    let ignore_path = tmp.path().join(".dupes-ignore.toml");
+    let content = std::fs::read_to_string(&ignore_path).unwrap();
+    let new_content = format!(
+        "{content}\n[[ignore]]\nfingerprint = \"deadbeefdeadbeef\"\nreason = \"stale entry\"\n"
+    );
+    std::fs::write(&ignore_path, new_content).unwrap();
+
+    // Run cleanup
+    cargo_dupes()
+        .args(["--path", tmp.path().to_str().unwrap(), "cleanup"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Removed stale entries"))
+        .stdout(predicate::str::contains("deadbeefdeadbeef"))
+        .stdout(predicate::str::contains("Removed 1 stale entries"));
+
+    // Verify the real fingerprint is still in the ignore file
+    cargo_dupes()
+        .args(["--path", tmp.path().to_str().unwrap(), "ignored"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(&real_fp));
+
+    // Verify the stale entry is gone
+    let final_content = std::fs::read_to_string(&ignore_path).unwrap();
+    assert!(!final_content.contains("deadbeefdeadbeef"));
+}
+
+#[test]
+fn cleanup_dry_run() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir_all(tmp.path().join("src")).unwrap();
+    std::fs::copy(
+        fixture_path("exact_dupes").join("src/lib.rs"),
+        tmp.path().join("src/lib.rs"),
+    )
+    .unwrap();
+
+    // Create an ignore file with a stale fingerprint only
+    let ignore_path = tmp.path().join(".dupes-ignore.toml");
+    std::fs::write(
+        &ignore_path,
+        "[[ignore]]\nfingerprint = \"deadbeefdeadbeef\"\nreason = \"stale\"\n",
+    )
+    .unwrap();
+
+    // Run cleanup with --dry-run
+    cargo_dupes()
+        .args([
+            "--path",
+            tmp.path().to_str().unwrap(),
+            "cleanup",
+            "--dry-run",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Stale entries (dry run)"))
+        .stdout(predicate::str::contains("deadbeefdeadbeef"))
+        .stdout(predicate::str::contains("would be removed"));
+
+    // Verify the file is unchanged
+    let content = std::fs::read_to_string(&ignore_path).unwrap();
+    assert!(content.contains("deadbeefdeadbeef"));
+}
+
 #[test]
 fn near_dupes_detected() {
     cargo_dupes()


### PR DESCRIPTION
## Summary

- **Composite fingerprints for near-duplicate groups**: Near-duplicate groups now receive a deterministic composite fingerprint (hash of sorted member fingerprints), enabling the `cargo dupes ignore <fp>` workflow for both exact and near duplicates. If group membership changes due to transitive closure shifts, the composite fingerprint changes and the ignore resurfaces for review.
- **`cleanup` subcommand**: New `cargo dupes cleanup` command prunes stale entries from `.dupes-ignore.toml` whose fingerprints no longer match any live duplicate group. Supports `--dry-run` to preview without modifying.
- **Near-duplicate text output**: Near-duplicate group headers now include the fingerprint alongside similarity and member count.

## Test plan

- [x] 3 new unit tests for `Fingerprint::from_fingerprints()` (order-independence, different-sets-differ, deterministic)
- [x] Updated grouper test for `Some(fp)` on near-duplicate groups
- [x] 4 new ignore module tests (near-dup filtering with/without match, stale detection, stale removal)
- [x] Updated text/JSON reporter tests for near-duplicate fingerprints
- [x] 3 new integration tests: `ignore_near_duplicate_workflow`, `cleanup_removes_stale_entries`, `cleanup_dry_run`
- [x] All 157 tests passing, clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)