### PR TITLE
fix(ci): add all workspace crates to release-please config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,30 +26,51 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
-      - name: Wait for dupes-core to be available on crates.io
+      - name: Wait for dupes-core on crates.io
         shell: bash
         run: |
           set -euo pipefail
-          # Determine the version of dupes-core to wait for
-          DUPES_CORE_VERSION="$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name == "dupes-core") | .version')"
-          echo "Waiting for dupes-core version ${DUPES_CORE_VERSION} to be available on crates.io..."
-
-          MAX_ATTEMPTS=10
-          SLEEP_SECONDS=15
-
-          for attempt in $(seq 1 "${MAX_ATTEMPTS}"); do
-            if curl -fsS "https://crates.io/api/v1/crates/dupes-core/${DUPES_CORE_VERSION}" > /dev/null; then
-              echo "dupes-core ${DUPES_CORE_VERSION} is now available on crates.io."
+          VERSION="$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name == "dupes-core") | .version')"
+          echo "Waiting for dupes-core ${VERSION}..."
+          for attempt in $(seq 1 10); do
+            if curl -fsS "https://crates.io/api/v1/crates/dupes-core/${VERSION}" > /dev/null; then
+              echo "dupes-core ${VERSION} is available."
               exit 0
             fi
-
-            echo "Attempt ${attempt}/${MAX_ATTEMPTS}: dupes-core ${DUPES_CORE_VERSION} not yet available. Sleeping for ${SLEEP_SECONDS}s..."
-            sleep "${SLEEP_SECONDS}"
+            echo "Attempt ${attempt}/10: not yet available. Sleeping 15s..."
+            sleep 15
           done
-
-          echo "Timed out waiting for dupes-core ${DUPES_CORE_VERSION} to appear on crates.io."
+          echo "Timed out waiting for dupes-core ${VERSION}."
           exit 1
+
+      - name: Publish dupes-rust
+        run: cargo publish -p dupes-rust
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Wait for dupes-rust on crates.io
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name == "dupes-rust") | .version')"
+          echo "Waiting for dupes-rust ${VERSION}..."
+          for attempt in $(seq 1 10); do
+            if curl -fsS "https://crates.io/api/v1/crates/dupes-rust/${VERSION}" > /dev/null; then
+              echo "dupes-rust ${VERSION} is available."
+              exit 0
+            fi
+            echo "Attempt ${attempt}/10: not yet available. Sleeping 15s..."
+            sleep 15
+          done
+          echo "Timed out waiting for dupes-rust ${VERSION}."
+          exit 1
+
       - name: Publish cargo-dupes
         run: cargo publish -p cargo-dupes
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Publish code-dupes
+        run: cargo publish -p code-dupes
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,40 +1,25 @@
 {
+  "release-type": "rust",
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
+  "include-component-in-tag": true,
+  "changelog-sections": [
+    {"type": "feat", "section": "Features", "hidden": false},
+    {"type": "fix", "section": "Bug Fixes", "hidden": false},
+    {"type": "perf", "section": "Performance Improvements", "hidden": false},
+    {"type": "revert", "section": "Reverts", "hidden": false},
+    {"type": "docs", "section": "Documentation", "hidden": false},
+    {"type": "style", "section": "Styles", "hidden": true},
+    {"type": "refactor", "section": "Code Refactoring", "hidden": false},
+    {"type": "test", "section": "Tests", "hidden": true},
+    {"type": "build", "section": "Build System", "hidden": true},
+    {"type": "ci", "section": "Continuous Integration", "hidden": true},
+    {"type": "chore", "section": "Miscellaneous", "hidden": true}
+  ],
   "packages": {
-    "dupes-core": {
-      "release-type": "rust",
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
-      "changelog-sections": [
-        {"type": "feat", "section": "Features", "hidden": false},
-        {"type": "fix", "section": "Bug Fixes", "hidden": false},
-        {"type": "perf", "section": "Performance Improvements", "hidden": false},
-        {"type": "revert", "section": "Reverts", "hidden": false},
-        {"type": "docs", "section": "Documentation", "hidden": false},
-        {"type": "style", "section": "Styles", "hidden": true},
-        {"type": "refactor", "section": "Code Refactoring", "hidden": false},
-        {"type": "test", "section": "Tests", "hidden": true},
-        {"type": "build", "section": "Build System", "hidden": true},
-        {"type": "ci", "section": "Continuous Integration", "hidden": true},
-        {"type": "chore", "section": "Miscellaneous", "hidden": true}
-      ]
-    },
-    "cargo-dupes": {
-      "release-type": "rust",
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true,
-      "changelog-sections": [
-        {"type": "feat", "section": "Features", "hidden": false},
-        {"type": "fix", "section": "Bug Fixes", "hidden": false},
-        {"type": "perf", "section": "Performance Improvements", "hidden": false},
-        {"type": "revert", "section": "Reverts", "hidden": false},
-        {"type": "docs", "section": "Documentation", "hidden": false},
-        {"type": "style", "section": "Styles", "hidden": true},
-        {"type": "refactor", "section": "Code Refactoring", "hidden": false},
-        {"type": "test", "section": "Tests", "hidden": true},
-        {"type": "build", "section": "Build System", "hidden": true},
-        {"type": "ci", "section": "Continuous Integration", "hidden": true},
-        {"type": "chore", "section": "Miscellaneous", "hidden": true}
-      ]
-    }
+    "dupes-core": {},
+    "dupes-rust": {},
+    "cargo-dupes": {},
+    "code-dupes": {}
   }
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,1 +1,1 @@
-{"dupes-core":"0.1.5","cargo-dupes":"0.1.5"}
+{"dupes-core":"0.1.5","dupes-rust":"0.1.5","cargo-dupes":"0.1.5","code-dupes":"0.1.5"}


### PR DESCRIPTION
## Summary

- Add `dupes-rust` and `code-dupes` to `.release-please-config.json` and `.release-please-manifest.json`
- Move shared config (release-type, changelog-sections) to top level to avoid duplication
- Add `include-component-in-tag: true` explicitly
- Update `release.yml` to publish all 4 crates in dependency order: `dupes-core` → `dupes-rust` → `cargo-dupes` + `code-dupes`

## Root cause

Release-please was failing because:
1. No `dupes-core-v0.1.5` tag/release existed (dupes-core was split out after the last release)
2. Release-please traversed the entire commit history looking for it, causing the GitHub App token to expire
3. `dupes-rust` and `code-dupes` were not in the config at all

## Fix

- Created baseline GitHub releases: `dupes-core-v0.1.5`, `dupes-rust-v0.1.5`, `code-dupes-v0.1.5`
- Added all 4 workspace crates to the release-please config and manifest

## Test plan

- [x] Verify all 4 releases exist: `gh release list`
- [ ] Verify release-please runs successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)