### PR TITLE
fix(ci): inline crate versions for release-please compatibility

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -21,5 +21,16 @@
     "dupes-rust": {},
     "cargo-dupes": {},
     "code-dupes": {}
-  }
+  },
+  "plugins": [
+    {
+      "type": "cargo-workspace",
+      "merge": false
+    },
+    {
+      "type": "linked-versions",
+      "groupName": "workspace",
+      "components": ["dupes-core", "dupes-rust", "cargo-dupes", "code-dupes"]
+    }
+  ]
 }

--- a/cargo-dupes/Cargo.toml
+++ b/cargo-dupes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-dupes"
-version.workspace = true
+version = "0.1.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/code-dupes/Cargo.toml
+++ b/code-dupes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "code-dupes"
-version.workspace = true
+version = "0.1.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/dupes-core/Cargo.toml
+++ b/dupes-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dupes-core"
-version.workspace = true
+version = "0.1.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/dupes-rust/Cargo.toml
+++ b/dupes-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dupes-rust"
-version.workspace = true
+version = "0.1.5"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Summary

- Replace `version.workspace = true` with inline `version = "0.1.5"` in all 4 crate `Cargo.toml` files
- Add `cargo-workspace` plugin to update inter-crate dependency versions on release
- Add `linked-versions` plugin to keep all 4 crates on the same version cycle

## Root cause

release-please does not support Cargo's `version.workspace = true` inheritance ([googleapis/release-please#2478](https://github.com/googleapis/release-please/issues/2478)). It fails with:

```
value at path package.version is not tagged
```

## Test plan

- [x] `cargo build --workspace` succeeds
- [x] `cargo clippy --workspace` clean
- [ ] Verify release-please runs successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)