### PR TITLE
fix: use is_excluded helper in scan_files instead of inline duplicate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["dupes-core", "dupes-rust", "cargo-dupes", "code-dupes"]
 resolver = "3"
 
 [workspace.package]
-version = "0.1.5"
+version = "0.2.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/mpecan/cargo-dupes"

--- a/dupes-core/src/scanner.rs
+++ b/dupes-core/src/scanner.rs
@@ -71,16 +71,9 @@ pub fn scan_files(config: &ScanConfig) -> Vec<PathBuf> {
                         .iter()
                         .any(|e| e.eq_ignore_ascii_case(ext))
                 })
+            && !is_excluded(path, &config.exclude_patterns)
         {
-            // Check exclude patterns
-            let path_str = path.to_string_lossy();
-            let excluded = config
-                .exclude_patterns
-                .iter()
-                .any(|pattern| path_str.contains(pattern.as_str()));
-            if !excluded {
-                files.push(path.to_path_buf());
-            }
+            files.push(path.to_path_buf());
         }
     }
 


### PR DESCRIPTION
## Summary

- Refactor `scan_files` in `dupes-core/src/scanner.rs` to use the existing `is_excluded()` helper instead of duplicating the exclude-check logic inline
- Update stale `[workspace.package] version` from `0.1.5` to `0.2.0` to match the current release

## Test plan

- [x] All 260 tests pass (`cargo test --workspace`)
- [x] Clippy clean (`cargo clippy --workspace`)
- [x] Format clean (`cargo fmt --all --check`)
- [x] Existing scanner tests verify exclude behavior still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)